### PR TITLE
 ♻️ refactor: 文字と画像認識どちらかを使用するように変更

### DIFF
--- a/emoji-recommend-workers/src/index.ts
+++ b/emoji-recommend-workers/src/index.ts
@@ -98,7 +98,8 @@ app.put("/emoji/generate-label", async (c) => {
     .map((label) => label.description)
     .join(" ");
 
-  const inputs = `${formattedText} ${formattedLabels}`;
+  // 文字認識の結果があればそれを採用し、なければ画像認識のラベルを採用する
+  const inputs = formattedText ?? formattedLabels;
 
   const body = JSON.stringify({ inputs: inputs });
   


### PR DESCRIPTION
自動ラベル生成の場合に、文字か画像どちらかの場合が圧倒的に多いため、
文字がある場合はラベルにそちらを採用し、文字が無い場合にのみ画像の情報を使用するように変更。